### PR TITLE
問い合わせ機能

### DIFF
--- a/app/assets/stylesheets/care_manager/booking_contacts.scss
+++ b/app/assets/stylesheets/care_manager/booking_contacts.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the care_manager/booking_contacts controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/care_manager/booking_contacts_controller.rb
+++ b/app/controllers/care_manager/booking_contacts_controller.rb
@@ -10,6 +10,7 @@ class CareManager::BookingContactsController < ApplicationController
     else
       if booking_contact.save
         flash.now[:notice] = "#{booking_contact.facility.name}へ問い合わせを送信しました。"
+        @use_plan.update(status: "contacting")
       else
         flash.now[:alert] = "問い合わせに失敗しました。"
       end

--- a/app/controllers/care_manager/booking_contacts_controller.rb
+++ b/app/controllers/care_manager/booking_contacts_controller.rb
@@ -1,4 +1,25 @@
 class CareManager::BookingContactsController < ApplicationController
   def create
+    @use_plan = UsePlan.find(params[:use_plan_id])
+    booking_contact = @use_plan.booking_contacts.new(booking_contact_params)
+    @booking_contact = BookingContact.new
+    @facilities = Facility.all
+    @booking_contacts = @use_plan.booking_contacts
+    if booking_contact.contacted?
+      flash.now[:alert] = "#{booking_contact.facility.name}への問い合わせはすでに送信済みのため送信を中止しました。"
+    else
+      if booking_contact.save
+        flash.now[:notice] = "#{booking_contact.facility.name}へ問い合わせを送信しました。"
+      else
+        flash.now[:alert] = "問い合わせに失敗しました。"
+      end
+    end
+    render 'care_manager/use_plans/show'
+  end
+
+  private
+
+  def booking_contact_params
+    params.require(:booking_contact).permit(:facility_id)
   end
 end

--- a/app/controllers/care_manager/booking_contacts_controller.rb
+++ b/app/controllers/care_manager/booking_contacts_controller.rb
@@ -1,0 +1,4 @@
+class CareManager::BookingContactsController < ApplicationController
+  def create
+  end
+end

--- a/app/controllers/care_manager/use_plans_controller.rb
+++ b/app/controllers/care_manager/use_plans_controller.rb
@@ -8,22 +8,24 @@ class CareManager::UsePlansController < ApplicationController
 
   def create
     @use_plan = UsePlan.new(use_plan_params)
-    @use_plan.care_manager_id = current_care_manager.id
-    if @use_plan.start_date.after?(@use_plan.end_date)
-      flash[:alert] = "終了日が開始日より前の日付になっています。"
-      render :new
-    else
+    if @use_plan.correct_date?  # 日付が正しいか判定します
+      @use_plan.care_manager_id = current_care_manager.id
       if @use_plan.save
         redirect_to care_manager_use_plans_path(@use_plan), notice: "利用計画が正常に作成されました。"
       else
         flash[:alert] = "利用計画作成中にエラーが発生しました。"
         render :new
       end
+    else
+      flash[:alert] = "入力された日付に問題があります。"
+      render :new
     end
   end
 
   def show
     @use_plan = UsePlan.find(params[:id])
+    @booking_contacts = BookingContact.new
+    @facilities = Facility.all
   end
 
   def edit
@@ -36,10 +38,15 @@ class CareManager::UsePlansController < ApplicationController
 
   def update
     @use_plan = UsePlan.find(params[:id])
-    if @use_plan.update(use_plan_params)
-      redirect_to care_manager_use_plans_path(@use_plan), notice: '利用計画が正常に更新されました。'
+    if UsePlan.new(use_plan_params).correct_date?
+      if @use_plan.update(use_plan_params)
+        redirect_to care_manager_use_plans_path(@use_plan), notice: '利用計画が正常に更新されました。'
+      else
+        flash[:alert] = "利用計画更新中にエラーが発生しました。"
+        render :edit
+      end
     else
-      flash[:alert] = "利用計画更新中にエラーが発生しました。"
+      flash[:alert] = "入力された日付に問題があります。"
       render :edit
     end
   end

--- a/app/controllers/care_manager/use_plans_controller.rb
+++ b/app/controllers/care_manager/use_plans_controller.rb
@@ -24,8 +24,9 @@ class CareManager::UsePlansController < ApplicationController
 
   def show
     @use_plan = UsePlan.find(params[:id])
-    @booking_contacts = BookingContact.new
+    @booking_contact = BookingContact.new
     @facilities = Facility.all
+    @booking_contacts = @use_plan.booking_contacts
   end
 
   def edit

--- a/app/helpers/care_manager/booking_contacts_helper.rb
+++ b/app/helpers/care_manager/booking_contacts_helper.rb
@@ -1,0 +1,2 @@
+module CareManager::BookingContactsHelper
+end

--- a/app/models/booking_contact.rb
+++ b/app/models/booking_contact.rb
@@ -1,4 +1,19 @@
 class BookingContact < ApplicationRecord
-  belongs_to :user_plan
+  belongs_to :use_plan
   belongs_to :facility
+
+  enum status: {
+    awaiting_reply: 0,
+    bookable: 1,
+    not_bookable: 2
+  }
+
+  # 問い合わせ済みの施設かチェックする
+  def contacted?
+    if self.use_plan.booking_contacts.exists?(facility_id: self.facility_id)
+      true
+    else
+      false
+    end
+  end
 end

--- a/app/models/use_plan.rb
+++ b/app/models/use_plan.rb
@@ -12,4 +12,16 @@ class UsePlan < ApplicationRecord
     confirmed: 2,
     canceled: 3
   }
+
+  # 入力された日付が正しいか判定するためのメソッド
+  def correct_date?
+    if self.start_date.before?(Date.today) || self.start_date.after?(self.end_date) || self.start_date == self.end_date
+      # 入所日が今日より前のとき
+      # 入所日が退所日より後のとき
+      # 入所日と退所日が同一のとき
+      false
+    else
+      true
+    end
+  end
 end

--- a/app/models/use_plan.rb
+++ b/app/models/use_plan.rb
@@ -3,6 +3,7 @@ class UsePlan < ApplicationRecord
   belongs_to :care_manager
   belongs_to :facility, optional: true  # 計画作成時
   has_many :use_plan_comments, dependent: :destroy
+  has_many :booking_contacts, dependent: :destroy
   validates :start_date, presence: true
   validates :end_date, presence: true
 

--- a/app/views/care_manager/use_plans/_form.html.erb
+++ b/app/views/care_manager/use_plans/_form.html.erb
@@ -2,15 +2,15 @@
 <table class="table table-hover bg-light shadow p-0">
   <tr>
     <th class="pt-3 text-nowrap text-center">ご利用者様</td>
-    <td><%= f.select :user_id, current_care_manager.users.map { |k| [ k.full_name + " 様", k.id ] }, { prompt: "選択してください" }, required: true, class: 'custom-select col-md-4' %></td>
+    <td><%= f.select :user_id, current_care_manager.users.map { |x| [ x.full_name + " 様", x.id ] }, { prompt: "選択してください" }, required: true, class: 'custom-select col-md-4' %></td>
   </tr>
   <tr>
     <th class="pt-3 text-nowrap text-center">入所日</td>
-    <td><%= f.date_field :start_date, required: true, class: 'custom-select col-md-4' %></td>
+    <td><%= f.date_field :start_date, required: true, class: 'custom-select col-md-4', min: Date.current %></td>
   </tr>
   <tr>
     <th class="pt-3 text-nowrap text-center">退所日</td>
-    <td><%= f.date_field :end_date, required: true, class: 'custom-select col-md-4' %></td>
+    <td><%= f.date_field :end_date, required: true, class: 'custom-select col-md-4', min: Date.current %></td>
   </tr>
   <tr>
     <th></th>

--- a/app/views/care_manager/use_plans/index.html.erb
+++ b/app/views/care_manager/use_plans/index.html.erb
@@ -23,7 +23,11 @@
                 <%= use_plan.user.full_name %> 様
               <% end %>
             </td>
-            <td><%= use_plan.start_date %> 〜 <%= use_plan.end_date %></td>
+            <td>
+              <%= link_to care_manager_use_plan_path(use_plan) do %>
+                <%= use_plan.start_date %> 〜 <%= use_plan.end_date %>
+              <% end %>
+            </td>
             <td><%= use_plan.status_i18n %></td>
             <td><%= link_to "編集", edit_care_manager_use_plan_path(use_plan.id), class: "btn btn-success btn-sm px-3 text-nowrap shadow" %></td>
           </tr>

--- a/app/views/care_manager/use_plans/show.html.erb
+++ b/app/views/care_manager/use_plans/show.html.erb
@@ -9,7 +9,9 @@
     <table class="table table-bordered table-responsive-md shadow">
       <tr>
         <th class="table-active text-nowrap" style="width:25%">ご利用者様</td>
-        <td style="width:75%"><%= @use_plan.user.full_name %></td>
+        <td style="width:75%">
+          <%= link_to @use_plan.user.full_name, care_manager_user_path(@use_plan.user) %>
+        </td>
       </tr>
       <tr>
         <th class="table-active text-nowrap">入所日</td>

--- a/app/views/care_manager/use_plans/show.html.erb
+++ b/app/views/care_manager/use_plans/show.html.erb
@@ -25,7 +25,13 @@
       </tr>
       <tr>
         <th class="table-active text-nowrap">利用先施設</td>
-        <td><%= @use_plan.facility.name %></td>
+        <td>
+          <% if @use_plan.facility_id.nil? %>
+            未定
+          <% else %>
+            <%= @use_plan.facility.name %>
+          <% end %>
+        </td>
       </tr>
       <tr>
         <th class="table-active text-nowrap">作成者</td>
@@ -38,3 +44,12 @@
     </table>
   </div>
 </div>
+
+<h1>問い合わせ先</h1>
+<%= form_with model: [@use_plan, @booking_contacts], url: care_manager_use_plan_booking_contacts_path(@use_plan.id) do |f| %>
+  <%= render "care_manager/shared/error_messages", resource: @booking_contacts %>
+  <%= f.select :facility_id, Facility.all.map { |x| [ x.name, x.id ] }, { prompt: "選択してください" }, required: true, class: 'custom-select col-md-4' %>
+  <div class="actions">
+    <%= f.submit "登録", class: 'btn btn-success' %>
+  </div>
+<% end %>

--- a/app/views/care_manager/use_plans/show.html.erb
+++ b/app/views/care_manager/use_plans/show.html.erb
@@ -45,7 +45,7 @@
   </div>
 </div>
 
-<h1>問い合わせ先</h1>
+<h1>問い合わせ先選択</h1>
 <%= form_with model: [@use_plan, @booking_contact], url: care_manager_use_plan_booking_contacts_path(@use_plan.id) do |f| %>
   <%= render "care_manager/shared/error_messages", resource: @booking_contact %>
   <%= f.select :facility_id, Facility.all.map { |x| [ x.name, x.id ] }, { prompt: "選択してください" }, required: true, class: 'custom-select col-md-4' %>

--- a/app/views/care_manager/use_plans/show.html.erb
+++ b/app/views/care_manager/use_plans/show.html.erb
@@ -1,7 +1,7 @@
 <h1>利用計画詳細</h1>
 <div class="row py-3">
   <div class="col">
-    <%= link_to "編集する", edit_care_manager_use_plan_path, class: "btn btn-success btn-sm px-3 col-md-2 shadow" %>
+    <%= link_to "編集する", edit_care_manager_use_plan_path(@use_plan), class: "btn btn-success btn-sm px-3 col-md-2 shadow" %>
   </div>
 </div>
 <div class="row mb-4">
@@ -21,7 +21,7 @@
       </tr>
       <tr>
         <th class="table-active text-nowrap">状態</td>
-        <td><%= @use_plan.status %></td>
+        <td><%= @use_plan.status_i18n %></td>
       </tr>
       <tr>
         <th class="table-active text-nowrap">利用先施設</td>
@@ -46,10 +46,30 @@
 </div>
 
 <h1>問い合わせ先</h1>
-<%= form_with model: [@use_plan, @booking_contacts], url: care_manager_use_plan_booking_contacts_path(@use_plan.id) do |f| %>
-  <%= render "care_manager/shared/error_messages", resource: @booking_contacts %>
+<%= form_with model: [@use_plan, @booking_contact], url: care_manager_use_plan_booking_contacts_path(@use_plan.id) do |f| %>
+  <%= render "care_manager/shared/error_messages", resource: @booking_contact %>
   <%= f.select :facility_id, Facility.all.map { |x| [ x.name, x.id ] }, { prompt: "選択してください" }, required: true, class: 'custom-select col-md-4' %>
   <div class="actions">
     <%= f.submit "登録", class: 'btn btn-success' %>
   </div>
 <% end %>
+
+<h2>問い合わせ状況</h2>
+<table class="table table-bordered table-responsive-md shadow">
+  <thead>
+    <tr>
+      <th class="table-active">問い合わせ日時</th>
+      <th class="table-active">送信済み施設</th>
+      <th class="table-active">状態</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @booking_contacts.each do |booking_contact| %>
+      <tr>
+        <td><%= booking_contact.created_at.strftime('%Y/%m/%d %H:%M:%S') %></td>
+        <td><%= booking_contact.facility.name %></td>
+        <td><%= booking_contact.status_i18n %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/care_manager/users/show.html.erb
+++ b/app/views/care_manager/users/show.html.erb
@@ -48,11 +48,11 @@
       </tr>
       <tr>
         <th class="table-active">生活歴</td>
-        <td><%= @user.life_history %></td>
+        <td><%= safe_join(@user.life_history.split("\n"),tag(:br)) %></td>
       </tr>
       <tr>
         <th class="table-active">病歴</td>
-        <td><%= @user.medical_history %></td>
+        <td><%= safe_join(@user.medical_history.split("\n"),tag(:br)) %></td>
       </tr>
     </table>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ module CareBookingStation
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Tokyo"
     # config.eager_load_paths << Rails.root.join("extras")
     config.i18n.default_locale = :ja
   end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -25,6 +25,11 @@ ja:
         contacting: "問い合わせ中"
         confirmed: "予約確定"
         canceled: "中止"
+    booking_contact:
+      status:
+        awaiting_reply: "返答待ち"
+        bookable: "予約可能"
+        not_bookable: "予約不可"
   date:
     formats:
       default: "%Y/%m/%d"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
 
   namespace :care_manager do
     resources :users, only: [:new, :create, :index, :show, :edit, :update]
-    resources :use_plans, only: [:new, :create, :index, :show, :edit, :update]
+    resources :use_plans, only: [:new, :create, :index, :show, :edit, :update] do
+      resources :booking_contacts, only: [:new, :create, :index, :show, :edit, :update]
+    end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,17 +5,93 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+# CareManager.create!(
+#     email: "hanako@mail.com",
+#     password: "testtest",
+#     last_name: "山田",
+#     first_name: "花子",
+#     last_name_kana: "やまだ",
+#     first_name_kana: "はなこ",
+#     address: "埼玉県花子市123",
+#     post_code: "1234567",
+#     phone_number: "08012345678",
+#     office_name: " 居宅介護支援事業所れいわ",
+#     is_deleted: false
+# )
 
 CareManager.create!(
-  email: "hanako@mail.com",
-  password: "testtest",
-  last_name: "山田",
-  first_name: "花子",
-  last_name_kana: "やまだ",
-  first_name_kana: "はなこ",
-  address: "埼玉県花子市８７８７",
-  post_code: "1111111",
-  phone_number: "08087878787",
-  office_name: " 居宅介護支援事業所れいわ",
-  is_deleted: false
+  [
+    {
+      email: "hanako@mail.com",
+      password: "testtest",
+      last_name: "山田",
+      first_name: "花子",
+      last_name_kana: "やまだ",
+      first_name_kana: "はなこ",
+      address: "埼玉県花子市123",
+      post_code: "1234567",
+      phone_number: "08012345678",
+      office_name: "居宅介護支援事業所れいわ",
+      is_deleted: false
+    },
+    {
+      email: "taro@mail.com",
+      password: "testtest",
+      last_name: "山田",
+      first_name: "太郎",
+      last_name_kana: "やまだ",
+      first_name_kana: "たろう",
+      address: "埼玉県太郎市123",
+      post_code: "1234567",
+      phone_number: "08023456789",
+      office_name: "居宅介護支援事業所へいせい",
+      is_deleted: false
+    }
+  ]
+)
+
+Facility.create!(
+  [
+    {
+      email: "reiwa@mail.com",
+      password: "testtest",
+      name: "ケアセンター令和",
+      kana_name: "ケアセンターレイワ",
+      address: "埼玉県令和市令和123",
+      post_code: "7654321",
+      phone_number: "0123456789",
+      is_deleted: false
+    },
+    {
+      email: "heisei@mail.com",
+      password: "testtest",
+      name: "ケアセンター平成",
+      kana_name: "ケアセンターヘイセイ",
+      address: "埼玉県平成市平成123",
+      post_code: "8765432",
+      phone_number: "1234567890",
+      is_deleted: false
+    }
+  ]
+)
+
+User.create!(
+  [
+    {
+      care_manager_id: 1,
+      last_name: "令和",
+      first_name: "道子",
+      last_name_kana: "レイワ",
+      first_name_kana: "ミチコ",
+      address: "埼玉県てすと市てすと123",
+      post_code: "1234567",
+      phone_number: "08012345678",
+      current_status: "home_care",
+      care_level_status: "long_term_care_level_1",
+      gender: "female",
+      birthday: Date.new(1937, 8, 30),
+      life_history: "○○小学校を卒業後、洋裁学校に通った。成人してからは文房具製造工場に勤め、結婚後は家業の農家を手伝っていた。夫は幼なじみで恋愛結婚であった。几帳面で面倒見の良い性格で、夫が亡くなってからも畑仕事に精を出しては近所に配ったりしていた。また、孫が顔を見せに行くと大変喜んでいた。現在は年金と長男からの仕送りで生活している。",
+      medical_history: "【既往歴】\r\nなし\r\n【現病歴】\r\n① 高血圧：平成 6 年（55 歳）頃診断。通院、内服治療を受けていた。② 糖尿病（II 型）：平成 6 年（55 歳）頃診断。通院、内服治療を受けていた。\r\n③ 両変形性膝関節症：平成 21 年（70 歳）診断。通院、内服治療を受けていた。\r\n④ アルツハイマー性認知症：平成 28 年（77 歳） △△病院にて確定診断され治療開始\r\n→①②③については、入所後は嘱託医が継続して診察する\r\n→④については、△△病院（脳神経内科 XXX 医師）に継続して通院する（連絡先：XXX-XXXX-XXXX）\r\n≪主治医≫\r\n嘱託医 ○○医師 （高血圧、糖尿病、変形性膝関節症の診察）"
+    }
+  ]
 )

--- a/test/controllers/care_manager/booking_contacts_controller_test.rb
+++ b/test/controllers/care_manager/booking_contacts_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CareManager::BookingContactsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
下記を追加
- 利用計画詳細ページへ追加：
   - 問い合わせ先施設選択フォームを追加
   - 現時点ではすべての施設から選択
   - 問い合わせ一覧表示
   - 利用者名に利用者詳細リンク
- 送信済みチェック機能
- 問い合わせ日時を正確に表示するためタイムゾーンをTokyoに変更
