### PR TITLE
契約記録機能追加

### DIFF
--- a/app/assets/stylesheets/facility/users.scss
+++ b/app/assets/stylesheets/facility/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the facility/users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/care_manager/booking_contacts_controller.rb
+++ b/app/controllers/care_manager/booking_contacts_controller.rb
@@ -40,12 +40,15 @@ class CareManager::BookingContactsController < ApplicationController
     # 利用計画に利用先施設を設定し、ステータスを予約完了にする
     if @use_plan.update(facility_id: facility.id, status: "confirmed")
       flash[:notice] = "利用先施設を「#{facility.name}」に確定しました。"
+      
       # 利用計画の問い合わせをすべて問い合わせ終了にする
       if @use_plan.booking_contacts.update_all(status: "closing")
         flash[:notice] += "問い合わせを締め切りました。"
       else
         flash[:alert] = "問い合わせの締め切りに失敗しました"
       end
+      
+      # 施設と利用者間の契約
     else
       flash[:alert] = "利用先の確定に失敗しました。"
     end

--- a/app/controllers/care_manager/booking_contacts_controller.rb
+++ b/app/controllers/care_manager/booking_contacts_controller.rb
@@ -40,15 +40,19 @@ class CareManager::BookingContactsController < ApplicationController
     # 利用計画に利用先施設を設定し、ステータスを予約完了にする
     if @use_plan.update(facility_id: facility.id, status: "confirmed")
       flash[:notice] = "利用先施設を「#{facility.name}」に確定しました。"
-      
+
       # 利用計画の問い合わせをすべて問い合わせ終了にする
       if @use_plan.booking_contacts.update_all(status: "closing")
         flash[:notice] += "問い合わせを締め切りました。"
       else
         flash[:alert] = "問い合わせの締め切りに失敗しました"
       end
-      
-      # 施設と利用者間の契約
+
+      # 施設と利用者間の契約がない場合
+      unless @use_plan.user.contracts.exists?(facility_id: facility.id)
+        contract = @use_plan.user.contracts.new
+        contract.update(facility_id: facility.id)
+      end
     else
       flash[:alert] = "利用先の確定に失敗しました。"
     end

--- a/app/controllers/care_manager/users_controller.rb
+++ b/app/controllers/care_manager/users_controller.rb
@@ -48,7 +48,7 @@ class CareManager::UsersController < ApplicationController
   def ensure_correct_care_manager
     user = User.find(params[:id])
     unless user.care_manager_id == current_care_manager.id
-      redirect_to care_manager_users_path, notice: '他のケアマネージャーが作成したご利用者様情報は閲覧できません。'
+      redirect_to care_manager_users_path, alert: '他のケアマネージャーが作成したご利用者様情報は閲覧できません。'
     end
   end
 end

--- a/app/controllers/facility/schedules_controller.rb
+++ b/app/controllers/facility/schedules_controller.rb
@@ -4,10 +4,7 @@ class Facility::SchedulesController < ApplicationController
     @today = Date.today
 
     # 今月のスケジュールをすべて取得
-    @schedules = current_facility.schedules.select { |schedule| schedule.date.month == @today.month }
-
-    # 今月利用がある利用者をすべて取得
-    @users = User.all
+    schedules = current_facility.schedules.select { |schedule| schedule.date.month == @today.month }
 
     # 予約表用に今月の日付を取得
     @days = @today.all_month
@@ -16,11 +13,11 @@ class Facility::SchedulesController < ApplicationController
 
     # 2次元ハッシュに利用詳細を格納
     @hash = Hash.new { |h,k| h[k] = {} }
-    @schedules.each do |schedule|
+    schedules.each do |schedule|
       date = schedule.date
       use_details = schedule.use_details
       use_details.each do |use_detail|
-        @hash[use_detail.user_id][date] = use_detail.status_i18n
+        @hash[use_detail.user][date] = use_detail.status_i18n
       end
     end
   end

--- a/app/controllers/facility/users_controller.rb
+++ b/app/controllers/facility/users_controller.rb
@@ -1,12 +1,26 @@
 class Facility::UsersController < ApplicationController
   before_action :authenticate_facility!
-  before_action :ensure_correct_facility, only: [:show]
+  before_action :ensure_correct_facility, only: [:show, :contract_change]
 
   def index
   end
 
   def show
-    @user = User.find(params[:id])
+    @is_contracted = current_facility.new_user?(@user)
+  end
+
+  # 利用者の契約状態を切り替えるアクション
+  def contract_change
+    contract = Contract.find_by(facility_id: current_facility.id, user_id: @user.id)
+    if contract.is_contracted
+      contract.update(is_contracted: false)
+      flash[:notice] = "#{@user.full_name} 様の契約状態を未契約にしました。"
+    else
+      contract.update(is_contracted: true)
+      flash[:notice] = "#{@user.full_name} 様を契約状態を契約済にしました。"
+    end
+    @is_contracted = contract.is_contracted
+    render :show
   end
 
   private

--- a/app/controllers/facility/users_controller.rb
+++ b/app/controllers/facility/users_controller.rb
@@ -3,11 +3,11 @@ class Facility::UsersController < ApplicationController
   before_action :ensure_correct_facility, only: [:show, :contract_change]
 
   def index
-    @users = facility.contracts
+    @users = current_facility.users
   end
 
   def show
-    @is_contracted = current_facility.new_user?(@user)
+    @is_new_user = current_facility.new_user?(@user)
   end
 
   # 利用者の契約状態を切り替えるアクション
@@ -21,7 +21,7 @@ class Facility::UsersController < ApplicationController
       flash[:notice] = "#{@user.full_name} 様を契約状態を契約済にしました。"
     end
     @is_contracted = contract.is_contracted
-    render :show
+    redirect_to request.referer
   end
 
   private

--- a/app/controllers/facility/users_controller.rb
+++ b/app/controllers/facility/users_controller.rb
@@ -1,0 +1,20 @@
+class Facility::UsersController < ApplicationController
+  before_action :authenticate_facility!
+  before_action :ensure_correct_facility, only: [:show]
+
+  def index
+  end
+
+  def show
+    @user = User.find(params[:id])
+  end
+
+  private
+
+  def ensure_correct_facility
+    @user = User.find(params[:id])
+    unless @user.contracts.exists?(facility_id: current_facility.id)
+      redirect_to request.referer, alert: '契約記録のないご利用者様情報は閲覧できません。'
+    end
+  end
+end

--- a/app/controllers/facility/users_controller.rb
+++ b/app/controllers/facility/users_controller.rb
@@ -3,6 +3,7 @@ class Facility::UsersController < ApplicationController
   before_action :ensure_correct_facility, only: [:show, :contract_change]
 
   def index
+    @users = facility.contracts
   end
 
   def show

--- a/app/helpers/facility/users_helper.rb
+++ b/app/helpers/facility/users_helper.rb
@@ -1,0 +1,2 @@
+module Facility::UsersHelper
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,7 +13,7 @@ import "bootstrap";
 import "../stylesheets/application"
 import '@fortawesome/fontawesome-free/js/all'
 import '../stylesheets/7-1-26.css'
-// import "4-1-4.js"
+import '../stylesheets/4-1-4.css'
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/stylesheets/4-1-4.css
+++ b/app/javascript/stylesheets/4-1-4.css
@@ -32,22 +32,12 @@
 
 /*========= レイアウトのためのCSS ===============*/
 
-
-#container{
-  width:100%;
+#container {
+  width: 100%;
   height: 100vh;
-  background: #ccc;
+  /*background: #ccc;*/
   display: flex;
   justify-content: center;
   align-items: center;
   text-align: center;
-}
-
-
-a{
-  color: #333;
-}
-
-a:hover{
-  text-decoration: none;
 }

--- a/app/javascript/stylesheets/7-1-26.css
+++ b/app/javascript/stylesheets/7-1-26.css
@@ -1,22 +1,3 @@
-@import url('https://fonts.googleapis.com/css?family=Sacramento');
-@import url('https://fonts.googleapis.com/css?family=M+PLUS+Rounded+1c');
-
-.logo {
-  font-family: 'Sacramento', cursive;
-  text-decoration: none;
-  color: #333;
-  font-size: 2em;
-}
-.logo:hover{
-  text-decoration: none;
-  color: #333;
-}
-
-
-body {
-  font-family: 'M PLUS 1p', sans-serif;
-}
-
 /*--- 線から塗り（共通設定） ---*/
 
 .btn05{

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -15,13 +15,13 @@ body {
   color: red;
 }
 
-a {
-  color: #333;
-}
+// a {
+//   color: #333;
+// }
 
-a:hover {
-  text-decoration: none;
-}
+// a:hover {
+//   text-decoration: none;
+// }
 
 .logo, .logo:hover {
   font-family: 'Sacramento', cursive;

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,5 +1,11 @@
 @import '~bootstrap/scss/bootstrap';
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';
+@import url('https://fonts.googleapis.com/css?family=Sacramento');
+@import url('https://fonts.googleapis.com/css?family=M+PLUS+Rounded+1c');
+
+body {
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+}
 
 #notice {
   color: green;
@@ -7,4 +13,19 @@
 
 #alert {
   color: red;
+}
+
+a {
+  color: #333;
+}
+
+a:hover {
+  text-decoration: none;
+}
+
+.logo, .logo:hover {
+  font-family: 'Sacramento', cursive;
+  text-decoration: none;
+  color: #333;
+  font-size: 2em;
 }

--- a/app/models/booking_contact.rb
+++ b/app/models/booking_contact.rb
@@ -62,7 +62,7 @@ class BookingContact < ApplicationRecord
   end
 
   # 問い合わせの利用計画の内容を施設スケジュールに反映するメソッド
-  def add_schdule
+  def save_schdule
     use_plan = self.use_plan
     from = use_plan.start_date
     to = use_plan.end_date
@@ -73,17 +73,18 @@ class BookingContact < ApplicationRecord
       schedule = self.facility.schedules.find_or_create_by(date: date)
 
       # 日付が該当するスケジュールの利用詳細を１つ作成
-      use_detail = schedule.use_details.new
+      use_detail = schedule.use_details.new(user_id: use_plan.user_id)
 
       # 利用詳細に格納するステータスを変更
       if date == from
-        status = "in"  # 入所日
+        use_detail.status = "in"  # 入所日
       elsif date == to
-        status = "out"  # 退所日
+        use_detail.status = "out"  # 退所日
       else
-        status = "all_day"  # 終日利用
+        use_detail.status = "all_day"  # 終日利用
       end
-      use_detail.update(user_id: use_plan.user_id, status: status)
+
+      use_detail.save
     end
   end
 end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -42,4 +42,10 @@ class Facility < ApplicationRecord
       facility.capacity = "20"
     end
   end
+
+  # 契約済みかどうかチェックする
+  def new_user?(user)
+    contract = Contract.find_by(facility_id: self.id, user_id: user.id)
+    return contract.is_contracted
+  end
 end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -7,6 +7,7 @@ class Facility < ApplicationRecord
   has_many :booking_contacts, dependent: :destroy
   has_many :use_plans, dependent: :destroy
   has_many :schedules, dependent: :destroy
+  has_many :users, through: :contracts
   validates :name, presence: true
   validates :kana_name, presence: true
   validates :address, presence: true
@@ -43,9 +44,9 @@ class Facility < ApplicationRecord
     end
   end
 
-  # 契約済みかどうかチェックする
+  # 未契約かどうかチェックする
   def new_user?(user)
     contract = Contract.find_by(facility_id: self.id, user_id: user.id)
-    return contract.is_contracted
+    return contract.is_contracted ? false : true
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :use_details, dependent: :destroy
   has_many :use_plans, dependent: :destroy
   has_many :contracts, dependent: :destroy
+  has_many :facilities, through: :contracts
   validates :last_name, presence: true
   validates :first_name, presence: true
   validates :last_name_kana, presence: true

--- a/app/views/facility/schedules/index.html.erb
+++ b/app/views/facility/schedules/index.html.erb
@@ -14,7 +14,7 @@
         <th class="text-nowrap"><%= link_to "#{user.full_name} 様", facility_user_path(user) %><%= "(新規)" if current_facility.new_user?(user) %></th>
         <% @days.each do |day| %>
           <td>
-            <%= @hash[user.id][day] %>
+            <%= @hash[user][day] %>
           </td>
         <% end %>
       </tr>

--- a/app/views/facility/schedules/index.html.erb
+++ b/app/views/facility/schedules/index.html.erb
@@ -1,4 +1,4 @@
-<h1><%= current_facility.name %>の利用スケジュール <%= "#{@today.year}年#{@today.month}月" %></h1>
+<h1><%= current_facility.name %>の利用予約表 <%= "#{@today.year}年#{@today.month}月" %></h1>
 <table class="table table-bordered table-responsive-md shadow">
   <thead>
     <tr>
@@ -11,7 +11,7 @@
   <tbody>
     <% @users.each do |user| %>
       <tr>
-        <th class="text-nowrap"><%= user.full_name %> 様</th>
+        <th class="text-nowrap"><%= link_to "#{user.full_name} 様", facility_user_path(user) %></th>
         <% @days.each do |day| %>
           <td>
             <%= @hash[user.id][day] %>

--- a/app/views/facility/schedules/index.html.erb
+++ b/app/views/facility/schedules/index.html.erb
@@ -9,9 +9,9 @@
     </tr>
   </thead>
   <tbody>
-    <% @users.each do |user| %>
+    <% @hash.keys.each do |user| %>
       <tr>
-        <th class="text-nowrap"><%= link_to "#{user.full_name} 様", facility_user_path(user) %></th>
+        <th class="text-nowrap"><%= link_to "#{user.full_name} 様", facility_user_path(user) %><%= "(新規)" if current_facility.new_user?(user) %></th>
         <% @days.each do |day| %>
           <td>
             <%= @hash[user.id][day] %>

--- a/app/views/facility/users/index.html.erb
+++ b/app/views/facility/users/index.html.erb
@@ -1,4 +1,4 @@
-<h1>契約利用者一覧</h1>
+<h1>施設利用者一覧</h1>
 <div class="row mb-4">
   <div class="col-md-8">
     <table class="table table-bordered table-responsive-md shadow">
@@ -7,20 +7,28 @@
           <th class="table-active">氏名</th>
           <th class="table-active">現在の状態</th>
           <th class="table-active">要介護度</th>
-          <th class="table-active"></th>
+          <th class="table-active">契約状態</th>
         </tr>
       </thead>
       <tbody>
         <% @users.each do |user| %>
           <tr>
             <td>
-              <%= link_to care_manager_user_path(user) do %>
+              <%= link_to facility_user_path(user) do %>
                 <%= user.full_name %> 様
               <% end %>
             </td>
             <td><%= user.current_status_i18n %></td>
             <td><%= user.care_level_status_i18n %></td>
-            <td><%= link_to "編集", edit_care_manager_user_path(user), class: "btn btn-success btn-sm px-3 text-nowrap shadow" %></td>
+            <td>
+              <% if current_facility.new_user?(user) %>
+                未契約
+                <%= link_to "契約済に変更", contract_change_facility_user_path(user), method: :patch, data: { confirm: "契約済に変更してよろしいですか？(対象のご利用者様：#{user.full_name})" }, class: 'btn btn-success' %>
+              <% else %>
+                契約済
+                <%= link_to "未契約に変更", contract_change_facility_user_path(user), method: :patch, data: { confirm: "未契約に変更してよろしいですか？(対象のご利用者様：#{user.full_name})" }, class: 'btn btn-success' %>
+              <% end %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/facility/users/index.html.erb
+++ b/app/views/facility/users/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Facility::Users#index</h1>
+<p>Find me in app/views/facility/users/index.html.erb</p>

--- a/app/views/facility/users/index.html.erb
+++ b/app/views/facility/users/index.html.erb
@@ -1,2 +1,29 @@
-<h1>Facility::Users#index</h1>
-<p>Find me in app/views/facility/users/index.html.erb</p>
+<h1>契約利用者一覧</h1>
+<div class="row mb-4">
+  <div class="col-md-8">
+    <table class="table table-bordered table-responsive-md shadow">
+      <thead>
+        <tr>
+          <th class="table-active">氏名</th>
+          <th class="table-active">現在の状態</th>
+          <th class="table-active">要介護度</th>
+          <th class="table-active"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @users.each do |user| %>
+          <tr>
+            <td>
+              <%= link_to care_manager_user_path(user) do %>
+                <%= user.full_name %> 様
+              <% end %>
+            </td>
+            <td><%= user.current_status_i18n %></td>
+            <td><%= user.care_level_status_i18n %></td>
+            <td><%= link_to "編集", edit_care_manager_user_path(user), class: "btn btn-success btn-sm px-3 text-nowrap shadow" %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/facility/users/show.html.erb
+++ b/app/views/facility/users/show.html.erb
@@ -10,12 +10,12 @@
       <tr>
         <th class="table-active" style="width:25%">契約状態</td>
         <td style="width:75%">
-          <% if @is_contracted %>
-            契約済
-            <%= link_to "未契約に変更", contract_change_facility_user_path(@user), method: :patch, data: { confirm: "未契約に変更してよろしいですか？(対象のご利用者様：#{@user.full_name})" }, class: 'btn btn-success' %>
-          <% else %>
+          <% if @is_new_user %>
             未契約
             <%= link_to "契約済に変更", contract_change_facility_user_path(@user), method: :patch, data: { confirm: "契約済に変更してよろしいですか？(対象のご利用者様：#{@user.full_name})" }, class: 'btn btn-success' %>
+          <% else %>
+            契約済
+            <%= link_to "未契約に変更", contract_change_facility_user_path(@user), method: :patch, data: { confirm: "未契約に変更してよろしいですか？(対象のご利用者様：#{@user.full_name})" }, class: 'btn btn-success' %>
           <% end %>
         </td>
       </tr>

--- a/app/views/facility/users/show.html.erb
+++ b/app/views/facility/users/show.html.erb
@@ -8,6 +8,18 @@
   <div class="col-md-8">
     <table class="table table-bordered table-responsive-md shadow">
       <tr>
+        <th class="table-active" style="width:25%">契約状態</td>
+        <td style="width:75%">
+          <% if @is_contracted %>
+            契約済
+            <%= link_to "未契約に変更", contract_change_facility_user_path(@user), method: :patch, data: { confirm: "未契約に変更してよろしいですか？(対象のご利用者様：#{@user.full_name})" }, class: 'btn btn-success' %>
+          <% else %>
+            未契約
+            <%= link_to "契約済に変更", contract_change_facility_user_path(@user), method: :patch, data: { confirm: "契約済に変更してよろしいですか？(対象のご利用者様：#{@user.full_name})" }, class: 'btn btn-success' %>
+          <% end %>
+        </td>
+      </tr>
+      <tr>
         <th class="table-active" style="width:25%">氏名</td>
         <td style="width:75%"><%= @user.last_name %> <%= @user.first_name %></td>
       </tr>

--- a/app/views/facility/users/show.html.erb
+++ b/app/views/facility/users/show.html.erb
@@ -1,0 +1,60 @@
+<h1><%= @user.last_name %> <%= @user.first_name %>様の詳細情報</h1>
+<div class="row py-3">
+  <div class="col">
+    <h5 class="font-weight-bold">登録情報</h5>
+  </div>
+</div>
+<div class="row mb-4">
+  <div class="col-md-8">
+    <table class="table table-bordered table-responsive-md shadow">
+      <tr>
+        <th class="table-active" style="width:25%">氏名</td>
+        <td style="width:75%"><%= @user.last_name %> <%= @user.first_name %></td>
+      </tr>
+      <tr>
+        <th class="table-active">カナ</td>
+        <td><%= @user.last_name_kana %> <%= @user.first_name_kana %></td>
+      </tr>
+      <tr>
+        <th class="table-active">郵便番号</td>
+        <td><%= @user.post_code %></td>
+      </tr>
+      <tr>
+        <th class="table-active">住所</td>
+        <td><%= @user.address %></td>
+      </tr>
+      <tr>
+        <th class="table-active">電話番号</td>
+        <td><%= @user.phone_number %></td>
+      </tr>
+      <tr>
+        <th class="table-active">性別</td>
+        <td><%= @user.gender_i18n %>	</td>
+      </tr>
+      <tr>
+        <th class="table-active">生年月日</td>
+        <td><%= @user.birthday %></td>
+      </tr>
+      <tr>
+        <th class="table-active">現在の状態</td>
+        <td><%= @user.current_status_i18n %></td>
+      </tr>
+      <tr>
+        <th class="table-active">要介護度</td>
+        <td><%= @user.care_level_status_i18n %></td>
+      </tr>
+      <tr>
+        <th class="table-active">生活歴</td>
+        <td><%= safe_join(@user.life_history.split("\n"),tag(:br)) %></td>
+      </tr>
+      <tr>
+        <th class="table-active">病歴</td>
+        <td><%= safe_join(@user.medical_history.split("\n"),tag(:br)) %></td>
+      </tr>
+      <tr>
+        <th class="table-active">担当ケアマネージャー</td>
+        <td><%= @user.care_manager.full_name %> (<%= @user.care_manager.office_name %>)</td>
+      </tr>
+    </table>
+  </div>
+</div>

--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -1,7 +1,11 @@
-<h1>ややこしい介護施設の利用予約。</h1>
-<h1><strong>Came Booking Station</strong>で簡単に。</h1>
+<div id="splash">
+  <div id="splash_text"></div>
+</div>
+<div id="container">
+  <h1>ややこしい介護施設の利用予約。<br><strong>Care Booking Station</strong>で簡単に。</h1>
 
-<div class="row mt-5">
-  <%= link_to '施設様ゲストログイン（閲覧用）', facility_guest_sign_in_path, class: "btn btn-secondary btn-sm btn-block mb-3 sign_in", method: :post %>
-  <%= link_to 'ケアマネージャー様ゲストログイン（閲覧用）', care_manager_guest_sign_in_path, class: "btn btn-secondary btn-sm btn-block mb-3 sign_in", method: :post %>
+  <div class="row mt-5">
+    <%= link_to '施設様ゲストログイン（閲覧用）', facility_guest_sign_in_path, class: "btn btn-secondary btn-sm btn-block mb-3 sign_in", method: :post %>
+    <%= link_to 'ケアマネージャー様ゲストログイン（閲覧用）', care_manager_guest_sign_in_path, class: "btn btn-secondary btn-sm btn-block mb-3 sign_in", method: :post %>
+  </div>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -23,7 +23,7 @@
             <%= link_to '利用計画一覧', care_manager_use_plans_path, method: :get, class: 'btn05 bordercircle1' %>
           </li>
           <li class="nav-item mr-1 text-nowrap">
-            <%= link_to '担当利用者様一覧', care_manager_users_path, method: :get, class: 'btn05 bordercircle1' %>
+            <%= link_to '利用者一覧', care_manager_users_path, method: :get, class: 'btn05 bordercircle1' %>
           </li>
           <li class="nav-item mr-1 text-nowrap">
             <%= link_to 'ログアウト', destroy_care_manager_session_path, method: :delete, class: 'btn05 bordercircle1' %>
@@ -42,7 +42,7 @@
             <%= link_to '問い合わせ一覧', facility_booking_contacts_path, method: :get, class: 'btn05 bordercircle1' %>
           </li>
           <li class="nav-item mr-1 text-nowrap">
-            <%= link_to '契約利用者様一覧', facility_users_path, method: :get, class: 'btn05 bordercircle1' %>
+            <%= link_to '利用者一覧', facility_users_path, method: :get, class: 'btn05 bordercircle1' %>
           </li>
           <li class="nav-item mr-1 text-nowrap">
             <%= link_to '予約表', facility_schedules_path, method: :get, class: 'btn05 bordercircle1' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,25 +8,16 @@
 
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <link rel="stylesheet" type="text/css" href="../stylesheets/7-1-26.css">
-    <link rel="stylesheet" type="text/css" href="../stylesheets/4-1-4.css">
   </head>
 
   <body>
-    <div id="splash">
-      <div id="splash_text"></div>
-    </div>
-    <div id="container">
       <%= render 'layouts/header' %>
       <main>
-        <div class="container my-5 mx-6-md pb-5">
-          <p id="notice"><%= notice %></p>
-          <p id="alert"><%= alert %></p>
-          <%= yield %>
-        </div>
+        <p id="notice"><%= notice %></p>
+        <p id="alert"><%= alert %></p>
+        <%= yield %>
       </main>
       <%= render 'layouts/footer' %>
-    </div>
     <!--<script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>-->
     <script src="https://rawgit.com/kimmobrunfeldt/progressbar.js/master/dist/progressbar.min.js"></script>
     <!--IE11用-->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,9 +55,11 @@ Rails.application.routes.draw do
 
   # 施設機能
   namespace :facility do
-    resources :users, only: [:index, :show]
+    resources :users, only: [:index, :show] do
+      patch 'contract_change' => "users#contract_change", on: :member
+    end
     resources :booking_contacts, only: [:index, :show] do
-     patch 'reply' => "booking_contacts#reply"
+      patch 'reply' => "booking_contacts#reply"
     end
     resources :schedules, only: [:index, :show, :create]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,7 @@ Rails.application.routes.draw do
 
   # 施設機能
   namespace :facility do
-    resources :users, only: [:index, :show, :update]
+    resources :users, only: [:index, :show]
     resources :booking_contacts, only: [:index, :show] do
      patch 'reply' => "booking_contacts#reply"
     end

--- a/db/migrate/20230108160533_create_contracts.rb
+++ b/db/migrate/20230108160533_create_contracts.rb
@@ -3,7 +3,7 @@ class CreateContracts < ActiveRecord::Migration[6.1]
     create_table :contracts do |t|
       t.integer :facility_id, null: false
       t.integer :user_id, null: false
-      t.boolean :is_deleted, null: false, default: false
+      t.boolean :is_contracted, null: false, default: false
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -72,7 +72,7 @@ ActiveRecord::Schema.define(version: 2023_01_08_161500) do
   create_table "contracts", force: :cascade do |t|
     t.integer "facility_id", null: false
     t.integer "user_id", null: false
-    t.boolean "is_deleted", default: false, null: false
+    t.boolean "is_contracted", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/test/controllers/facility/users_controller_test.rb
+++ b/test/controllers/facility/users_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Facility::UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get facility_users_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get facility_users_show_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
- トップページのローディングを修正
- 施設側：
  - 契約記録機能追加
  - 施設利用者一覧ページ
- ケアマネージャー側：
  - 予約確定処理修正：予約確定時に契約関係を未契約で作成し、施設が利用者情報を閲覧可能にしました。
- ヘッダーボタン名修正